### PR TITLE
fix:add executable start.sh script and update Dockerfile, closes #14

### DIFF
--- a/api/Dockerfile.prod
+++ b/api/Dockerfile.prod
@@ -1,25 +1,55 @@
+# # --- 构建阶段 ---
+# FROM node:18-alpine AS builder
+# WORKDIR /app
+# COPY package*.json ./
+# RUN npm install
+# COPY . .
+# # 运行 Prisma Generate，确保客户端是最新的
+# RUN npx prisma generate
+# # 使用 tsc 编译 TypeScript 代码
+# RUN npm run build 
+# # (需要在 package.json 中添加 "build": "tsc")
+
+# # --- 生产阶段 ---
+# FROM node:18-alpine
+# WORKDIR /app
+# # 从构建阶段复制编译好的代码和 node_modules
+# COPY --from=builder /app/dist ./dist
+# COPY --from=builder /app/node_modules ./node_modules
+# # 复制 prisma schema 以便运行时使用
+# COPY --from=builder /app/prisma ./prisma
+# COPY package*.json ./
+
+# EXPOSE 4000
+# # 生产模式下直接用 node 运行编译后的 JS 文件
+# CMD ["node", "dist/index.js"]
+
+
 # --- 构建阶段 ---
 FROM node:18-alpine AS builder
 WORKDIR /app
 COPY package*.json ./
 RUN npm install
-COPY . .
-# 运行 Prisma Generate，确保客户端是最新的
+COPY prisma ./prisma/
 RUN npx prisma generate
-# 使用 tsc 编译 TypeScript 代码
+COPY . .
+# 确保 package.json 中有 "build": "tsc"
 RUN npm run build 
-# (需要在 package.json 中添加 "build": "tsc")
 
 # --- 生产阶段 ---
 FROM node:18-alpine
 WORKDIR /app
-# 从构建阶段复制编译好的代码和 node_modules
+# 从构建阶段复制所有需要的文件
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/node_modules ./node_modules
-# 复制 prisma schema 以便运行时使用
 COPY --from=builder /app/prisma ./prisma
-COPY package*.json ./
+COPY --from=builder /app/package.json ./package.json
 
-EXPOSE 4000
-# 生产模式下直接用 node 运行编译后的 JS 文件
-CMD ["node", "dist/index.js"]
+# 【核心修正】复制并使用我们的启动脚本
+COPY --from=builder /app/start.sh ./start.sh
+
+# Render 会通过 PORT 环境变量来指定端口，这里 EXPOSE 更多是文档作用
+EXPOSE 10000
+
+# 【核心修正】容器的默认命令现在是执行我们的启动脚本
+CMD ["./start.sh"]

--- a/api/start.sh
+++ b/api/start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# 如果任何命令失败，则立即退出
+set -e
+
+# 执行数据库迁移
+echo "==> Running database migrations..."
+npx prisma migrate deploy
+
+# 启动主应用
+echo "==> Starting application..."
+exec node dist/index.js


### PR DESCRIPTION
根本原因：
这通常是由于 Render 平台的启动生命周期和我们复合命令 (... && ...) 之间存在一些难以预测的交互导致的。最稳健的解决方案，是将这个“先迁移、后启动”的逻辑封装到一个启动脚本文件中，让 Render 只执行这一个脚本，而不是在输入框里执行复杂的复合命令。